### PR TITLE
add arcType to polyline and polygon

### DIFF
--- a/public/czml/czml_styling_data.czml
+++ b/public/czml/czml_styling_data.czml
@@ -23,7 +23,8 @@
         ]
       },
       width: 5,
-      clampToGround: true
+      clampToGround: true,
+      "arcType": "GEODESIC"
     }
   },
   {
@@ -37,7 +38,8 @@
           139.720, 35.6900069, 0,
           139.680, 35.7109591, 0
         ]
-      }
+      },
+      "arcType": "GEODESIC"
     }
   }
   ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced geospatial rendering of visual elements: Polyline and polygon shapes now follow geodesic curves, ensuring a more natural and accurate depiction on maps without altering existing ground-level functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->